### PR TITLE
Add certificates section to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,6 +640,19 @@
             </div>
         </div>
     </section>
+    <section class="mb-20">
+        <h2 class="text-4xl font-bold mb-5">Certificates</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 max-w-3xl mx-auto">
+            <a href="https://aws.amazon.com/certification/certified-cloud-practitioner/" class="block group" target="_blank" rel="noopener noreferrer">
+                <img src="https://img.shields.io/badge/AWS%20Cloud%20Practitioner-FF9900?style=for-the-badge&amp;logo=amazonaws&amp;logoColor=white" alt="AWS Cloud Practitioner" class="w-full h-auto rounded-lg border border-gray-700 group-hover:border-gray-500 transition-all">
+                <p class="mt-2 text-center text-xl">AWS Cloud Practitioner</p>
+            </a>
+            <a href="https://www.comptia.org/certifications/security" class="block group" target="_blank" rel="noopener noreferrer">
+                <img src="https://img.shields.io/badge/CompTIA%20Security%2B-ED1C24?style=for-the-badge&amp;logo=comptia&amp;logoColor=white" alt="CompTIA Security+" class="w-full h-auto rounded-lg border border-gray-700 group-hover:border-gray-500 transition-all">
+                <p class="mt-2 text-center text-xl">CompTIA Security+</p>
+            </a>
+        </div>
+    </section>
 
     <section>
         <h2 class="text-4xl font-bold mb-5">Experience</h2>


### PR DESCRIPTION
## Summary
- add Certificates section using external badge images and links
- avoid storing local binary images

## Testing
- `hugo --minify` *(fails: Unable to locate config file or config directory)*
- `python3 -m http.server 1313` and `curl -s http://localhost:1313 | rg Certificates -n`


------
https://chatgpt.com/codex/tasks/task_e_68c0975fecb48329934f719cb38c47f3